### PR TITLE
Update architecture detector to handle Apple Silicon macs

### DIFF
--- a/src/main/kotlin/com/pswidersk/gradle/helm/HelmPluginUtils.kt
+++ b/src/main/kotlin/com/pswidersk/gradle/helm/HelmPluginUtils.kt
@@ -40,6 +40,8 @@ internal fun arch(): String {
     val arch = System.getProperty("os.arch")
     return if (arch == "x86_64") {
         "amd64"
+    } else if (arch == "aarch64") {
+      	"arm64"
     } else {
         arch
     }


### PR DESCRIPTION
When building on a newer Apple Silicon Mac computer, the `os.arch` property reports as `aarch64`. However, the arch string Helm uses in their filenames is `arm64`, so the build fails unless you override the system property.

This change should handle the architecture discrepancy.